### PR TITLE
Fix java example

### DIFF
--- a/src/main/java/org/example/embedding/Main.java
+++ b/src/main/java/org/example/embedding/Main.java
@@ -77,7 +77,7 @@ public class Main {
                         break;
                     case "java":
                         // with Java we invoke System.out.println reflectively.
-                        Value out = context.getBindings("java").getMember("System").getMember("out");
+                        Value out = context.getBindings("java").getMember("java.lang.System").getMember("out");
                         out.invokeMember("println", "Hello Espresso Java!");
                         break;
                 }


### PR DESCRIPTION
Fix the lookup of `java.lang.System`.

With that change + changing the dependency from `org.graalvm.polyglot:js` to `org.graalvm.polyglot:languages` i was able to locally test the languages successfully on GraalVM for JDK 21 and OpenJDK 21+35 release candidates.