### PR TITLE
Added maven profiles to build an uber jar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Download Maven or import as Maven project into your IDE.
 * `mvn test` to run the tests
 * `mvn exec:exec` to run the Main application
 * `mvn -Pnative package` to build a native-image
+* `mvn -Passembly package` to build an uber JAR containing all dependencies using the Maven Assembly Plugin. The resulting JAR can be executed using `java -jar embedding-1.0-SNAPSHOT-jar-with-dependencies.jar`. We do recommend not using shading whenever possible.
+* `mvn -Pshade package` to build an uber JAR containing all dependencies using the Maven Shade Plugin. The resulting JAR can be executed using `java -jar embedding-1.0-SNAPSHOT.jar`. We do recommend not using shading whenever possible.
 
 Please see the [pom.xml](./pom.xml) file for further details on the configuration.
 

--- a/assembly.xml
+++ b/assembly.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <!-- Select the GraalVM version to use. -->
-        <graalvm.version>23.1.0</graalvm.version>
+        <graalvm.version>23.1.2</graalvm.version>
     </properties>
 
     <dependencies>
@@ -311,6 +311,75 @@
             </build>
         </profile>
 
+        <profile>
+            <id>assembly</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <archive>
+                                        <manifest>
+                                            <mainClass>org.example.embedding.Main</mainClass>
+                                        </manifest>
+                                    </archive>
+                                    <descriptors>
+                                        <descriptor>assembly.xml</descriptor>
+                                    </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>shade</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.example.embedding.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*:*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Added Maven profiles for building an uber JAR using the Maven Assembly and Maven Shade plugins. Note that to support the uber JAR, GraalVM version 23.1.2 or later is required, as uber JARs do not work with classpath isolation.
